### PR TITLE
Added SSH key authentication support.

### DIFF
--- a/ssh.py
+++ b/ssh.py
@@ -45,16 +45,17 @@ def _create_ssh_client(target_ip, auth_username, password, verbose=False):
     """
     Create and return a connected paramiko SSHClient.
     
-    If ``password`` is falsy (None or empty string), authentication falls back
-    to standard SSH key-based auth: the SSH agent (if running) and the default
-    key files under ``~/.ssh/`` (id_rsa, id_ecdsa, id_ed25519, etc.) are used.
-    If ``password`` is provided, only password auth is attempted — no implicit
-    key fallback, because explicit is better than implicit.
+    If ``password`` is ``None``, authentication falls back to standard SSH
+    key-based auth: the SSH agent (if running) and the default key files under
+    ``~/.ssh/`` (id_rsa, id_ecdsa, id_ed25519, etc.) are used. Any other value
+    — including an empty string — is treated as an explicit password and only
+    password auth is attempted; no implicit key fallback, because explicit is
+    better than implicit.
     
     Args:
         target_ip: The IP address or hostname of the remote host.
         auth_username: The username for authentication (may include DOMAIN\\user).
-        password: The password for authentication, or a falsy value to use keys.
+        password: The password for authentication, or ``None`` to use keys.
         verbose: If True, print detailed status messages.
     
     Returns:
@@ -67,9 +68,10 @@ def _create_ssh_client(target_ip, auth_username, password, verbose=False):
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     
-    # If no password was supplied, use standard SSH key-based auth
-    # (agent + default key files in ~/.ssh/).
-    use_key_auth = not password
+    # If no password was supplied (sentinel: None), use standard SSH
+    # key-based auth (agent + default key files in ~/.ssh/). An empty
+    # string is still treated as an explicit (if lousy) password.
+    use_key_auth = password is None
     
     if verbose:
         auth_mode = "key-based (agent + ~/.ssh/)" if use_key_auth else "password"
@@ -80,7 +82,7 @@ def _create_ssh_client(target_ip, auth_username, password, verbose=False):
             hostname=target_ip,
             port=22,
             username=auth_username,
-            password=password if not use_key_auth else None,
+            password=password,
             timeout=30,
             allow_agent=use_key_auth,
             look_for_keys=use_key_auth,

--- a/ssh.py
+++ b/ssh.py
@@ -45,10 +45,16 @@ def _create_ssh_client(target_ip, auth_username, password, verbose=False):
     """
     Create and return a connected paramiko SSHClient.
     
+    If ``password`` is falsy (None or empty string), authentication falls back
+    to standard SSH key-based auth: the SSH agent (if running) and the default
+    key files under ``~/.ssh/`` (id_rsa, id_ecdsa, id_ed25519, etc.) are used.
+    If ``password`` is provided, only password auth is attempted — no implicit
+    key fallback, because explicit is better than implicit.
+    
     Args:
         target_ip: The IP address or hostname of the remote host.
         auth_username: The username for authentication (may include DOMAIN\\user).
-        password: The password for authentication.
+        password: The password for authentication, or a falsy value to use keys.
         verbose: If True, print detailed status messages.
     
     Returns:
@@ -61,15 +67,23 @@ def _create_ssh_client(target_ip, auth_username, password, verbose=False):
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     
+    # If no password was supplied, use standard SSH key-based auth
+    # (agent + default key files in ~/.ssh/).
+    use_key_auth = not password
+    
+    if verbose:
+        auth_mode = "key-based (agent + ~/.ssh/)" if use_key_auth else "password"
+        print(f"[*] SSH auth mode: {auth_mode} for {auth_username}@{target_ip}")
+    
     try:
         client.connect(
             hostname=target_ip,
             port=22,
             username=auth_username,
-            password=password,
+            password=password if not use_key_auth else None,
             timeout=30,
-            allow_agent=False,
-            look_for_keys=False,
+            allow_agent=use_key_auth,
+            look_for_keys=use_key_auth,
         )
     except paramiko.AuthenticationException as e:
         if verbose:

--- a/tomoe.py
+++ b/tomoe.py
@@ -847,8 +847,8 @@ if __name__ == "__main__":
     if args.password is None:
         if args.protocol != "ssh":
             parser.error(f"-p/--password is required for protocol '{args.protocol}' (only ssh supports key-based auth)")
-        # Empty-string password signals key-based auth to the ssh layer.
-        passwords = [""]
+        # None signals key-based auth to the ssh layer; "" remains a real password value.
+        passwords = [None]
     else:
         passwords = parse_target_or_file(args.password, expand_entries=False)
 

--- a/tomoe.py
+++ b/tomoe.py
@@ -770,7 +770,7 @@ if __name__ == "__main__":
     parser.add_argument("target", metavar="IP", help="target host IP/hostname or path to file with targets (one per line)")
     parser.add_argument("-d", "--domain", default="", help="domain of selected user")
     parser.add_argument("-u", "--username", required=True, help="username or path to file with usernames (one per line)")
-    parser.add_argument("-p", "--password", required=True, help="password or path to file with passwords (one per line)")
+    parser.add_argument("-p", "--password", default=None, help="password or path to file with passwords (one per line). Optional for ssh: if omitted, SSH key-based auth is used (agent + ~/.ssh/ keys).")
 
     parser.add_argument("--os", choices=["windows", "linux"], default="windows", dest="target_os",
                         help="target host OS (default: windows). Only applies to SSH protocol.")
@@ -842,8 +842,16 @@ if __name__ == "__main__":
         parser.error(str(exc))
 
     usernames = parse_target_or_file(args.username, expand_entries=False)
-    passwords = parse_target_or_file(args.password, expand_entries=False)
-    
+
+    # Password handling: required for smb/winrm, optional for ssh (key-based auth).
+    if args.password is None:
+        if args.protocol != "ssh":
+            parser.error(f"-p/--password is required for protocol '{args.protocol}' (only ssh supports key-based auth)")
+        # Empty-string password signals key-based auth to the ssh layer.
+        passwords = [""]
+    else:
+        passwords = parse_target_or_file(args.password, expand_entries=False)
+
     # Validate that we have at least one host, username, and password.
     if not hosts:
         parser.error(f"no hosts found in '{args.target}' (file is empty or contains only whitespace)")
@@ -855,7 +863,10 @@ if __name__ == "__main__":
     console = Console()
     console.print()
     console.print(f"  Targets: {len(hosts)} host(s)")
-    console.print(f"  Credentials: {len(usernames)} user(s) x {len(passwords)} password(s)")
+    if args.password is None and args.protocol == "ssh":
+        console.print(f"  Credentials: {len(usernames)} user(s) x SSH key auth")
+    else:
+        console.print(f"  Credentials: {len(usernames)} user(s) x {len(passwords)} password(s)")
     console.print(f"  Protocol: {args.protocol}")
     if args.upload:
         console.print(f"  Operation: Upload {source} -> {dest}")


### PR DESCRIPTION
This PR adds key support. It checks the user's `.ssh` directory for keys starting with `id_*` and uses them against the target host.

This pull request improves SSH authentication flexibility and user experience in the tool by allowing SSH key-based authentication when no password is provided, while still requiring passwords for other protocols. The CLI and SSH connection logic are updated to reflect and support this behavior, including clearer argument handling and user feedback.

**SSH Authentication Improvements:**

* Updated `_create_ssh_client` in `ssh.py` to support SSH key-based authentication (via agent and default key files) when no password is supplied, and to use password authentication exclusively when a password is provided. The function docstring and connection logic were updated accordingly. [[1]](diffhunk://#diff-c44b134b6e146fb4b5008de86c2808244b4d2189580ae81affeafd78fd1da343R48-R57) [[2]](diffhunk://#diff-c44b134b6e146fb4b5008de86c2808244b4d2189580ae81affeafd78fd1da343R70-R86)

**CLI Argument and Validation Enhancements:**

* Made the `--password` argument optional for SSH in the CLI, with a new help message explaining that key-based authentication is used if omitted.
* Added logic to require a password for non-SSH protocols (SMB/WinRM), while defaulting to key-based authentication for SSH if no password is provided.

**User Feedback Improvements:**

* Improved credential summary output: now informs the user when SSH key authentication is being used, instead of displaying a password count.