### PR TITLE
Interactive WinRM Shell, and PyPi automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tomoe-exec
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Verify tag matches pyproject version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg_version=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag" != "$pkg_version" ]; then
+            echo "Release tag ($tag) does not match pyproject.toml version ($pkg_version)" >&2
+            exit 1
+          fi
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 Credentials/
 Scripts/
 hosts
+build/
+dist/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "tomoe-exec"
+version = "1.0.4"
+description = "Remote administration over WinRM, SMB, or SSH."
+requires-python = ">=3.10"
+dependencies = [
+    "pypsexec>=0.3.0",
+    "pypsrp>=0.8.0",
+    "paramiko>=3.0.0",
+    "rich>=13.0.0",
+    "smbprotocol>=1.16.0",
+]
+
+[project.scripts]
+tomoe = "tomoe:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["tomoe", "wsman", "smb", "ssh"]

--- a/tomoe.py
+++ b/tomoe.py
@@ -47,7 +47,7 @@ class LiveLogHandler(logging.Handler):
 
 
 from smb import run_psexec, run_smb_copy, run_smb_download
-from wsman import run_winrm, run_winrm_copy, run_winrm_download
+from wsman import run_winrm, run_winrm_copy, run_winrm_download, run_winrm_shell, WinRMAuthenticationError
 from ssh import run_ssh, run_ssh_copy, run_ssh_download
 
 
@@ -457,6 +457,52 @@ def execute_on_host(
     )
 
 
+def run_interactive_shell(host, usernames, passwords, domain, verbose, console) -> int:
+    """Try credentials in order against a single host; on first auth success,
+    drop into an interactive PowerShell REPL. Returns a process exit code:
+    0 clean exit, 2 all credentials failed, 1 other error, 130 Ctrl-C during auth.
+
+    Mirrors the auth-error string-matching from execute_on_host so behavior is
+    consistent: any exception whose message matches an auth pattern is treated
+    as 'try the next credential'."""
+    auth_error_patterns = [
+        "logon_failure", "access_denied", "authentication",
+        "login failed", "invalid credentials", "unauthorized",
+        "status_logon_failure", "kerberos", "credentials were rejected",
+        "bad password", "wrong password", "access is denied",
+        "rejected", "401"
+    ]
+
+    for username in usernames:
+        for password in passwords:
+            console.print(f"[dim]Authenticating as {username}@{host}...[/dim]")
+            try:
+                run_winrm_shell(
+                    target_ip=host,
+                    username=username,
+                    password=password,
+                    domain=domain,
+                    verbose=verbose,
+                )
+                return 0
+            except WinRMAuthenticationError:
+                console.print(f"[yellow]Auth failed for {username}, trying next...[/yellow]")
+                continue
+            except KeyboardInterrupt:
+                console.print("\n[yellow]Interrupted.[/yellow]")
+                return 130
+            except Exception as e:
+                msg = str(e).lower()
+                if any(p in msg for p in auth_error_patterns):
+                    console.print(f"[yellow]Auth failed for {username}, trying next...[/yellow]")
+                    continue
+                console.print(f"[red]Error: {e}[/red]")
+                return 1
+
+    console.print("[red]All credentials failed.[/red]")
+    return 2
+
+
 def run_concurrent_execution(
     hosts: list[str],
     usernames: list[str],
@@ -760,7 +806,7 @@ def write_output_files(results: list[HostResult], output_dir: str, console: Cons
     console.print(f"[bold]Output:[/bold] Wrote {written_count} file(s) to {output_dir}/")
 
 
-if __name__ == "__main__":
+def main():
     # Parse arguments.
     parser = argparse.ArgumentParser(
         usage="tomoe.py {smb, winrm, ssh} <ip/file> -u <username/file> -p <password/file> [--script <script> | --command <command> | --upload <source> <dest> | --download <source> <dest>]",
@@ -789,6 +835,7 @@ if __name__ == "__main__":
     parser.add_argument("-a", "--args", default="", help="arguments to pass to the script")
     parser.add_argument("--shell", choices=["powershell", "cmd"], default="powershell", help="shell type for SMB protocol (default: powershell)")
     parser.add_argument("--no-encrypt", dest="encrypt", action="store_false", default=True, help="disable SMB encryption (encryption is enabled by default)")
+    parser.add_argument("-i", "--interactive", action="store_true", help="drop into an interactive PowerShell session on the remote host (winrm only, single host)")
     parser.add_argument("-v", "--verbose", action="store_true", help="show verbose status messages")
     parser.add_argument("--show-failures", action="store_true", help="show failed hosts in the compact-mode completion log")
     parser.add_argument("-t", "--threads", type=int, default=10, help="maximum concurrent threads (default: 10)")
@@ -803,6 +850,12 @@ if __name__ == "__main__":
     # Validate protocol-specific arguments.
     if args.protocol != "smb" and args.shell != "powershell":
         parser.error("--shell is only supported when --protocol smb; for winrm and ssh, PowerShell is always used")
+
+    if args.interactive:
+        if args.protocol != "winrm":
+            parser.error("--interactive is only supported with the winrm protocol")
+        if args.command or args.script or args.upload or args.download:
+            parser.error("--interactive cannot be combined with --command, --script, --upload, or --download")
     
     # Extract source/dest and download flag from the parsed arguments.
     source = None
@@ -826,8 +879,8 @@ if __name__ == "__main__":
             parser.error(f"local destination parent directory not found: {dest_parent}")
     else:
         # Command execution mode
-        if not args.script and not args.command:
-            parser.error("either --script, --command, --upload, or --download is required")
+        if not args.script and not args.command and not args.interactive:
+            parser.error("either --script, --command, --upload, --download, or --interactive is required")
     
     # Set logging level based on verbose flag.
     if args.verbose:
@@ -840,6 +893,9 @@ if __name__ == "__main__":
         hosts = parse_target_or_file(args.target)
     except ValueError as exc:
         parser.error(str(exc))
+
+    if args.interactive and len(hosts) > 1:
+        parser.error(f"--interactive requires a single target host (got {len(hosts)})")
 
     usernames = parse_target_or_file(args.username, expand_entries=False)
 
@@ -876,6 +932,19 @@ if __name__ == "__main__":
             console.print(f"  Note: Per-host subdirectories will be created under {dest}")
     console.print()
 
+    # Interactive shell: skip the Live UI / thread pool entirely and hand
+    # stdin/stdout to the user once a credential authenticates.
+    if args.interactive:
+        exit_code = run_interactive_shell(
+            host=hosts[0],
+            usernames=usernames,
+            passwords=passwords,
+            domain=args.domain,
+            verbose=args.verbose,
+            console=console,
+        )
+        raise SystemExit(exit_code)
+
     # Run concurrent execution.
     results, compact_mode = run_concurrent_execution(
         hosts=hosts,
@@ -904,3 +973,7 @@ if __name__ == "__main__":
     # Write output files if output directory specified.
     if args.output:
         write_output_files(results, args.output, console)
+
+
+if __name__ == "__main__":
+    main()

--- a/wsman.py
+++ b/wsman.py
@@ -283,9 +283,12 @@ def _handle_transfer(line, remote_cwd, local_cwd, target_ip, username, password,
       upload <local>     -> drops basename(local) into the remote cwd
       download <remote>  -> drops basename(remote) into the local cwd captured
                             when the shell session started
+
+    Parse with ``posix=False`` so Windows-style backslashes are preserved.
+    Paths containing spaces should still be quoted.
     """
     try:
-        tokens = shlex.split(line)
+        tokens = shlex.split(line, posix=False)
     except ValueError as e:
         print(f"ERROR: could not parse arguments: {e}")
         return

--- a/wsman.py
+++ b/wsman.py
@@ -1,8 +1,16 @@
 import os
+import shlex
 import socket
 from pypsrp.powershell import PowerShell, RunspacePool
 from pypsrp.wsman import WSMan
 from pypsrp.client import Client
+
+# Importing readline enables arrow-key line editing and history for input().
+# Not available on stock Windows Python; harmless to skip there.
+try:
+    import readline  # noqa: F401
+except ImportError:
+    pass
 
 
 class WinRMAuthenticationError(Exception):
@@ -206,6 +214,210 @@ def run_winrm(target_ip, username, password, domain="", script_path=None, comman
         if verbose:
             print(f"[!] WinRM execution failed: {e}")
         raise
+
+
+def run_winrm_shell(target_ip, username, password, domain="", verbose=False):
+    """
+    Open a persistent PowerShell runspace on a remote Windows host and run an
+    interactive REPL on stdin/stdout. Authentication errors raised during the
+    handshake propagate as WinRMAuthenticationError so the caller can rotate
+    credentials; runtime errors during the REPL are rendered to the user and
+    do not propagate.
+    """
+    if not check_port_open(target_ip, 5985, timeout=5):
+        raise WinRMConnectionError(f"Port 5985 not reachable on {target_ip}")
+
+    auth_username = f"{domain}\\{username}" if domain else username
+
+    try:
+        wsman = WSMan(
+            server=target_ip,
+            port=5985,
+            username=auth_username,
+            password=password,
+            ssl=False,
+            auth="ntlm",
+            encryption="auto",
+            connection_timeout=30,
+            read_timeout=30,
+        )
+        # Capture the local working directory at session start so 'download'
+        # always lands files where the user invoked the shell from, even if
+        # the parent process changes cwd later.
+        local_cwd = os.getcwd()
+
+        with RunspacePool(wsman) as pool:
+            # Past this point, authentication has succeeded.
+            _repl_loop(pool, target_ip=target_ip, username=username,
+                       password=password, domain=domain, verbose=verbose,
+                       local_cwd=local_cwd)
+
+    except Exception as e:
+        error_str = str(e).lower()
+
+        if any(auth_err in error_str for auth_err in [
+            "unauthorized", "401", "authentication", "logon_failure",
+            "access_denied", "invalid credentials", "kerberos", "ntlm",
+            "denied", "rejected"
+        ]):
+            if verbose:
+                print(f"[!] WinRM authentication failed: {e}")
+            raise WinRMAuthenticationError(f"Authentication failed for {username}@{target_ip}: {e}")
+
+        if any(conn_err in error_str for conn_err in [
+            "connection", "timeout", "refused", "unreachable", "reset"
+        ]):
+            if verbose:
+                print(f"[!] WinRM connection failed: {e}")
+            raise WinRMConnectionError(f"Connection failed to {target_ip}: {e}")
+
+        if verbose:
+            print(f"[!] WinRM shell failed: {e}")
+        raise
+
+
+def _handle_transfer(line, remote_cwd, local_cwd, target_ip, username, password, domain, verbose):
+    """Parse and dispatch a single 'upload' or 'download' built-in line.
+
+    Evil-winrm-style: each takes exactly one path.
+      upload <local>     -> drops basename(local) into the remote cwd
+      download <remote>  -> drops basename(remote) into the local cwd captured
+                            when the shell session started
+    """
+    try:
+        tokens = shlex.split(line)
+    except ValueError as e:
+        print(f"ERROR: could not parse arguments: {e}")
+        return
+
+    cmd = tokens[0].lower()
+    args = tokens[1:]
+
+    if cmd == "upload":
+        if len(args) != 1:
+            print("Usage: upload <local>")
+            return
+        local = args[0]
+        if not os.path.exists(local):
+            print(f"ERROR: local source not found: {local}")
+            return
+        remote_name = os.path.basename(local.rstrip("/\\")) or os.path.basename(local)
+        if not remote_cwd:
+            print("ERROR: remote cwd unknown; cannot resolve upload destination")
+            return
+        remote_dest = remote_cwd.rstrip("\\") + "\\" + remote_name
+        try:
+            output = run_winrm_copy(
+                target_ip=target_ip, username=username, password=password,
+                domain=domain, source=local, dest=remote_dest,
+                verbose=verbose,
+            )
+            print(output)
+        except Exception as e:
+            print(f"ERROR: upload failed: {e}")
+        return
+
+    # download
+    if len(args) != 1:
+        print("Usage: download <remote>")
+        return
+    remote = args[0]
+    local_name = os.path.basename(remote.replace("\\", "/").rstrip("/")) or "downloaded_file"
+    local_dest = os.path.join(local_cwd, local_name)
+    try:
+        output = run_winrm_download(
+            target_ip=target_ip, username=username, password=password,
+            domain=domain, source=remote, dest=local_dest,
+            verbose=verbose,
+        )
+        print(output)
+    except Exception as e:
+        print(f"ERROR: download failed: {e}")
+
+
+def _get_remote_cwd(pool):
+    """Query the remote runspace for its current location. Returns None if
+    the query fails so the caller can fall back to a static prompt."""
+    try:
+        ps = PowerShell(pool)
+        ps.add_script("(Get-Location).Path")
+        ps.invoke()
+        for item in ps.output:
+            text = str(item).strip()
+            if text:
+                return text
+    except Exception:
+        pass
+    return None
+
+
+def _repl_loop(pool, target_ip, username, password, domain, verbose, local_cwd):
+    """Read-eval-print loop against an open RunspacePool. State (variables,
+    cwd, imported modules) persists across iterations because the runspace
+    is reused; only the PowerShell pipeline is rebuilt each command.
+
+    Credentials and the local starting cwd are passed through so the
+    'upload' and 'download' built-ins can spin up file-transfer
+    connections via the existing helpers."""
+    while True:
+        cwd = _get_remote_cwd(pool)
+        prompt = f"PS {cwd}> " if cwd else "PS> "
+        try:
+            line = input(prompt)
+        except EOFError:
+            print()
+            return
+        except KeyboardInterrupt:
+            # Ctrl-C at the prompt: clear the line, re-prompt.
+            print()
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.lower() in ("exit", "quit"):
+            return
+
+        first_token = stripped.split(None, 1)[0].lower()
+        if first_token in ("upload", "download"):
+            _handle_transfer(stripped, remote_cwd=cwd, local_cwd=local_cwd,
+                             target_ip=target_ip, username=username,
+                             password=password, domain=domain, verbose=verbose)
+            continue
+
+        ps = PowerShell(pool)
+        # Wrap user input in a dot-sourced script block piped through
+        # Out-String -Stream. This makes the remote PowerShell run its own
+        # format engine (so 'cat', 'ls', etc. render the way they would
+        # interactively) and return plain strings, sidestepping pypsrp's
+        # PSObject __str__ quirks. Dot-sourcing keeps variables and other
+        # session state in the caller's scope so REPL state still persists.
+        ps.add_script(". { " + line + " } | Out-String -Stream")
+
+        try:
+            ps.invoke()
+        except KeyboardInterrupt:
+            try:
+                ps.stop()
+            except Exception:
+                pass
+            print("^C")
+            continue
+        except Exception as e:
+            print(f"ERROR: {e}")
+            continue
+
+        for item in ps.output:
+            if item is None:
+                continue
+            print(item)
+        if hasattr(ps, "streams"):
+            for info in ps.streams.information or []:
+                print(info.message_data)
+            for warning in ps.streams.warning or []:
+                print(f"WARNING: {warning}")
+            for error in ps.streams.error or []:
+                print(f"ERROR: {error}")
 
 
 def run_winrm_copy(target_ip, username, password, domain="", source="", dest="", verbose=False, status_callback=None):

--- a/wsman.py
+++ b/wsman.py
@@ -325,12 +325,25 @@ def _handle_transfer(line, remote_cwd, local_cwd, target_ip, username, password,
         print("Usage: download <remote>")
         return
     remote = args[0]
-    local_name = os.path.basename(remote.replace("\\", "/").rstrip("/")) or "downloaded_file"
+    # run_winrm_download opens its own pypsrp Client, which starts in the
+    # default remote dir (typically C:\Windows\System32) — not the
+    # interactive runspace's current dir. Resolve relative paths against
+    # the prompt's remote_cwd so 'download file.txt' Just Works.
+    remote_normalized = remote.replace("/", "\\")
+    is_absolute = (len(remote_normalized) >= 2 and remote_normalized[1] == ":") or remote_normalized.startswith("\\\\")
+    if is_absolute:
+        remote_resolved = remote
+    else:
+        if not remote_cwd:
+            print("ERROR: remote cwd unknown; pass an absolute path")
+            return
+        remote_resolved = remote_cwd.rstrip("\\") + "\\" + remote_normalized.lstrip("\\")
+    local_name = os.path.basename(remote_resolved.replace("\\", "/").rstrip("/")) or "downloaded_file"
     local_dest = os.path.join(local_cwd, local_name)
     try:
         output = run_winrm_download(
             target_ip=target_ip, username=username, password=password,
-            domain=domain, source=remote, dest=local_dest,
+            domain=domain, source=remote_resolved, dest=local_dest,
             verbose=verbose,
         )
         print(output)


### PR DESCRIPTION
This pull request introduces a new interactive PowerShell shell feature for WinRM connections, along with several related enhancements and improvements to the `tomoe-exec` project. The main addition is a `--interactive` mode that allows users to open a persistent remote PowerShell session, supporting built-in upload/download commands and retaining session state. The changes also include packaging metadata for PyPI publication and improvements to the CLI structure.

Key changes:

**New Interactive Shell Feature:**

* Added a `--interactive` CLI flag (WinRM only) that opens a persistent interactive PowerShell REPL on the remote host, allowing users to execute commands, upload, and download files in-session. This includes robust credential rotation and error handling for authentication failures. (`tomoe.py`, `wsman.py`) [[1]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R460-R505) [[2]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R838) [[3]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R854-R859) [[4]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384L829-R883) [[5]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R897-R899) [[6]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R935-R947) [[7]](diffhunk://#diff-b8e9a79c4ac68fcafe50cf53deb4f083c550b58d0630f561b2799dacea9222e3R219-R422)
* Implemented the `run_winrm_shell` function and supporting REPL logic in `wsman.py`, including built-in `upload` and `download` commands and remote working directory tracking. (`wsman.py`)
* Added credential error pattern matching and user feedback for authentication failures in interactive mode. (`tomoe.py`, `wsman.py`) [[1]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R460-R505) [[2]](diffhunk://#diff-b8e9a79c4ac68fcafe50cf53deb4f083c550b58d0630f561b2799dacea9222e3R219-R422)

**CLI and Entry Point Improvements:**

* Refactored the CLI entry point: moved main logic into a `main()` function and updated the script entry point for packaging. (`tomoe.py`) [[1]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384L763-R809) [[2]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R976-R979)
* Improved argument validation to ensure `--interactive` is only used with WinRM and not combined with incompatible options. (`tomoe.py`) [[1]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R854-R859) [[2]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384L829-R883) [[3]](diffhunk://#diff-c226fbf8cf84829430d5df9092b89ba13d5d187641b1c4f8ae2b3b5dc17c2384R897-R899)

**Packaging and Release Automation:**

* Added a `pyproject.toml` with project metadata, dependencies, and build configuration for PyPI publication. (`pyproject.toml`)
* Introduced a GitHub Actions workflow to build and publish the package to PyPI on release. (`.github/workflows/release.yml`)

**Minor Enhancements:**

* Enabled readline support for improved line editing in the interactive shell, where available. (`wsman.py`)
* Updated imports to provide required symbols for the new shell feature. (`tomoe.py`)